### PR TITLE
Add minimal Dapper API with JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+**/bin/
+**/obj/

--- a/EmployeeTasks.sln
+++ b/EmployeeTasks.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D0F40D3F-D196-4F1E-A45B-4AB7A32FFAF0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmployeeTasks.Domain", "src\EmployeeTasks.Domain\EmployeeTasks.Domain.csproj", "{C2C1D865-D71D-4D84-8882-27AFBAE5BA43}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmployeeTasks.Application", "src\EmployeeTasks.Application\EmployeeTasks.Application.csproj", "{7EA8F4B0-6B49-4C99-B110-A6EB108C9CE1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmployeeTasks.Infrastructure", "src\EmployeeTasks.Infrastructure\EmployeeTasks.Infrastructure.csproj", "{93AEFDD4-7840-4D81-AE00-8982759C489C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmployeeTasks.Api", "src\EmployeeTasks.Api\EmployeeTasks.Api.csproj", "{2DF44EAB-220C-4485-937E-0AB57A151565}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C2C1D865-D71D-4D84-8882-27AFBAE5BA43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2C1D865-D71D-4D84-8882-27AFBAE5BA43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2C1D865-D71D-4D84-8882-27AFBAE5BA43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2C1D865-D71D-4D84-8882-27AFBAE5BA43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EA8F4B0-6B49-4C99-B110-A6EB108C9CE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EA8F4B0-6B49-4C99-B110-A6EB108C9CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EA8F4B0-6B49-4C99-B110-A6EB108C9CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EA8F4B0-6B49-4C99-B110-A6EB108C9CE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93AEFDD4-7840-4D81-AE00-8982759C489C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93AEFDD4-7840-4D81-AE00-8982759C489C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93AEFDD4-7840-4D81-AE00-8982759C489C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93AEFDD4-7840-4D81-AE00-8982759C489C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DF44EAB-220C-4485-937E-0AB57A151565}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DF44EAB-220C-4485-937E-0AB57A151565}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DF44EAB-220C-4485-937E-0AB57A151565}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DF44EAB-220C-4485-937E-0AB57A151565}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C2C1D865-D71D-4D84-8882-27AFBAE5BA43} = {D0F40D3F-D196-4F1E-A45B-4AB7A32FFAF0}
+		{7EA8F4B0-6B49-4C99-B110-A6EB108C9CE1} = {D0F40D3F-D196-4F1E-A45B-4AB7A32FFAF0}
+		{93AEFDD4-7840-4D81-AE00-8982759C489C} = {D0F40D3F-D196-4F1E-A45B-4AB7A32FFAF0}
+		{2DF44EAB-220C-4485-937E-0AB57A151565} = {D0F40D3F-D196-4F1E-A45B-4AB7A32FFAF0}
+	EndGlobalSection
+EndGlobal

--- a/src/EmployeeTasks.Api/EmployeeTasks.Api.csproj
+++ b/src/EmployeeTasks.Api/EmployeeTasks.Api.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\EmployeeTasks.Application\EmployeeTasks.Application.csproj" />
+    <ProjectReference Include="..\EmployeeTasks.Infrastructure\EmployeeTasks.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/EmployeeTasks.Api/Endpoints/AuthenticationEndpoints.cs
+++ b/src/EmployeeTasks.Api/Endpoints/AuthenticationEndpoints.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using EmployeeTasks.Application.Users.Commands;
+using EmployeeTasks.Application.Users.Queries;
+using MediatR;
+
+namespace EmployeeTasks.Api.Endpoints;
+
+public static class AuthenticationEndpoints
+{
+    public static void MapAuthenticationEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/register", async (RegisterUserCommand command, IMediator mediator) =>
+        {
+            var id = await mediator.Send(command);
+            return Results.Ok(new { id });
+        });
+
+        app.MapPost("/login", async (LoginUserQuery query, IMediator mediator) =>
+        {
+            var token = await mediator.Send(query);
+            if (token == null) return Results.Unauthorized();
+            return Results.Ok(new { token });
+        });
+    }
+}

--- a/src/EmployeeTasks.Api/Endpoints/EmployeeTaskEndpoints.cs
+++ b/src/EmployeeTasks.Api/Endpoints/EmployeeTaskEndpoints.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using EmployeeTasks.Domain.Entities;
+using EmployeeTasks.Application.Common.Interfaces;
+
+namespace EmployeeTasks.Api.Endpoints;
+
+public static class EmployeeTaskEndpoints
+{
+    public static void MapEmployeeTaskEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/tasks", async (EmployeeTask task, IEmployeeTaskRepository repo) =>
+        {
+            var id = await repo.EmployeesTasks_Create(task);
+            return Results.Ok(new { id });
+        }).RequireAuthorization();
+    }
+}

--- a/src/EmployeeTasks.Api/Program.cs
+++ b/src/EmployeeTasks.Api/Program.cs
@@ -1,0 +1,47 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using EmployeeTasks.Api.Endpoints;
+using EmployeeTasks.Application;
+using EmployeeTasks.Infrastructure.Repositories;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using EmployeeTasks.Application.Common.Interfaces;
+using EmployeeTasks.Application.Users.Commands;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("Jwt"));
+var jwtOptions = builder.Configuration.GetSection("Jwt").Get<JwtOptions>() ?? new JwtOptions();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwtOptions.Issuer,
+            ValidAudience = jwtOptions.Audience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.Key))
+        };
+    });
+
+builder.Services.AddAuthorization();
+builder.Services.AddMediatR(typeof(EmployeeTasks.Application.Users.Commands.RegisterUserCommand).Assembly);
+
+builder.Services.AddTransient<IDbConnection>(sp => new SqlConnection(builder.Configuration.GetConnectionString("Default")));
+builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddScoped<IEmployeeTaskRepository, EmployeeTaskRepository>();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapAuthenticationEndpoints();
+app.MapEmployeeTaskEndpoints();
+
+app.Run();

--- a/src/EmployeeTasks.Api/Properties/launchSettings.json
+++ b/src/EmployeeTasks.Api/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:32242",
+      "sslPort": 44305
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5135",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7192;http://localhost:5135",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/EmployeeTasks.Api/appsettings.Development.json
+++ b/src/EmployeeTasks.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/EmployeeTasks.Api/appsettings.json
+++ b/src/EmployeeTasks.Api/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Jwt": {
+    "Key": "SuperSecretKey12345",
+    "Issuer": "EmployeeTasks",
+    "Audience": "EmployeeTasksUsers"
+  },
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\mssqllocaldb;Database=EmployeeTasksDB;Trusted_Connection=True;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/EmployeeTasks.Application/Common/Interfaces/IEmployeeTaskRepository.cs
+++ b/src/EmployeeTasks.Application/Common/Interfaces/IEmployeeTaskRepository.cs
@@ -1,0 +1,8 @@
+using EmployeeTasks.Domain.Entities;
+
+namespace EmployeeTasks.Application.Common.Interfaces;
+
+public interface IEmployeeTaskRepository
+{
+    Task<int> EmployeesTasks_Create(EmployeeTask task);
+}

--- a/src/EmployeeTasks.Application/Common/Interfaces/IUserRepository.cs
+++ b/src/EmployeeTasks.Application/Common/Interfaces/IUserRepository.cs
@@ -1,0 +1,9 @@
+using EmployeeTasks.Domain.Entities;
+
+namespace EmployeeTasks.Application.Common.Interfaces;
+
+public interface IUserRepository
+{
+    Task<string> Users_Create(User user);
+    Task<User?> Users_GetByUserName(string userName);
+}

--- a/src/EmployeeTasks.Application/EmployeeTasks.Application.csproj
+++ b/src/EmployeeTasks.Application/EmployeeTasks.Application.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\EmployeeTasks.Domain\EmployeeTasks.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="11.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.5" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/EmployeeTasks.Application/JwtOptions.cs
+++ b/src/EmployeeTasks.Application/JwtOptions.cs
@@ -1,0 +1,8 @@
+namespace EmployeeTasks.Application;
+
+public class JwtOptions
+{
+    public string Key { get; set; } = string.Empty;
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+}

--- a/src/EmployeeTasks.Application/Users/Commands/RegisterUserCommand.cs
+++ b/src/EmployeeTasks.Application/Users/Commands/RegisterUserCommand.cs
@@ -1,0 +1,6 @@
+using EmployeeTasks.Domain.Entities;
+using MediatR;
+
+namespace EmployeeTasks.Application.Users.Commands;
+
+public record RegisterUserCommand(string FullName, string UserName, string Password, string PhoneNumber, string Address) : IRequest<string>;

--- a/src/EmployeeTasks.Application/Users/Commands/RegisterUserHandler.cs
+++ b/src/EmployeeTasks.Application/Users/Commands/RegisterUserHandler.cs
@@ -1,0 +1,28 @@
+using EmployeeTasks.Domain.Entities;
+using MediatR;
+using EmployeeTasks.Application.Common.Interfaces;
+
+namespace EmployeeTasks.Application.Users.Commands;
+
+public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, string>
+{
+    private readonly IUserRepository _repository;
+
+    public RegisterUserHandler(IUserRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<string> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    {
+        var user = new User
+        {
+            FullName = request.FullName,
+            UserName = request.UserName,
+            Password = request.Password,
+            PhoneNumber = request.PhoneNumber,
+            Address = request.Address
+        };
+        return await _repository.Users_Create(user);
+    }
+}

--- a/src/EmployeeTasks.Application/Users/Queries/LoginUserHandler.cs
+++ b/src/EmployeeTasks.Application/Users/Queries/LoginUserHandler.cs
@@ -1,0 +1,45 @@
+using EmployeeTasks.Application.Common.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Options;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace EmployeeTasks.Application.Users.Queries;
+
+public class LoginUserHandler : IRequestHandler<LoginUserQuery, string?>
+{
+    private readonly IUserRepository _repository;
+    private readonly JwtOptions _options;
+
+    public LoginUserHandler(IUserRepository repository, IOptions<JwtOptions> options)
+    {
+        _repository = repository;
+        _options = options.Value;
+    }
+
+    public async Task<string?> Handle(LoginUserQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _repository.Users_GetByUserName(request.UserName);
+        if (user == null || user.Password != request.Password)
+        {
+            return null;
+        }
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.UserID ?? string.Empty),
+            new Claim(ClaimTypes.Name, user.UserName ?? string.Empty)
+        };
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.Key));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: _options.Issuer,
+            audience: _options.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/src/EmployeeTasks.Application/Users/Queries/LoginUserQuery.cs
+++ b/src/EmployeeTasks.Application/Users/Queries/LoginUserQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace EmployeeTasks.Application.Users.Queries;
+
+public record LoginUserQuery(string UserName, string Password) : IRequest<string?>;

--- a/src/EmployeeTasks.Domain/EmployeeTasks.Domain.csproj
+++ b/src/EmployeeTasks.Domain/EmployeeTasks.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/EmployeeTasks.Domain/Entities/Employee.cs
+++ b/src/EmployeeTasks.Domain/Entities/Employee.cs
@@ -1,0 +1,14 @@
+namespace EmployeeTasks.Domain.Entities;
+
+public class Employee
+{
+    public int EmployeeID { get; set; }
+    public string? EmployeeName { get; set; }
+    public string? PhoneNumber { get; set; }
+    public string? Address { get; set; }
+    public DateTime? DateOfBirth { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? UpdatedDate { get; set; }
+    public bool IsDelete { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/src/EmployeeTasks.Domain/Entities/EmployeeTask.cs
+++ b/src/EmployeeTasks.Domain/Entities/EmployeeTask.cs
@@ -1,0 +1,12 @@
+namespace EmployeeTasks.Domain.Entities;
+
+public class EmployeeTask
+{
+    public int EmployeeTaskID { get; set; }
+    public int EmployeeID { get; set; }
+    public string? Task { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? UpdatedDate { get; set; }
+    public bool IsDelete { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/src/EmployeeTasks.Domain/Entities/User.cs
+++ b/src/EmployeeTasks.Domain/Entities/User.cs
@@ -1,0 +1,15 @@
+namespace EmployeeTasks.Domain.Entities;
+
+public class User
+{
+    public string? UserID { get; set; }
+    public string? FullName { get; set; }
+    public string? UserName { get; set; }
+    public string? Password { get; set; }
+    public string? PhoneNumber { get; set; }
+    public string? Address { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? UpdatedDate { get; set; }
+    public bool IsDelete { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/src/EmployeeTasks.Infrastructure/EmployeeTasks.Infrastructure.csproj
+++ b/src/EmployeeTasks.Infrastructure/EmployeeTasks.Infrastructure.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\EmployeeTasks.Application\EmployeeTasks.Application.csproj" />
+    <ProjectReference Include="..\EmployeeTasks.Domain\EmployeeTasks.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/EmployeeTasks.Infrastructure/Repositories/EmployeeTaskRepository.cs
+++ b/src/EmployeeTasks.Infrastructure/Repositories/EmployeeTaskRepository.cs
@@ -1,0 +1,24 @@
+using System.Data;
+using Dapper;
+using EmployeeTasks.Domain.Entities;
+using EmployeeTasks.Application.Common.Interfaces;
+
+namespace EmployeeTasks.Infrastructure.Repositories;
+
+public class EmployeeTaskRepository : IEmployeeTaskRepository
+{
+    private readonly IDbConnection _dbConnection;
+
+    public EmployeeTaskRepository(IDbConnection dbConnection)
+    {
+        _dbConnection = dbConnection;
+    }
+
+    public async Task<int> EmployeesTasks_Create(EmployeeTask task)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("@EmployeeID", task.EmployeeID);
+        parameters.Add("@Task", task.Task);
+        return await _dbConnection.ExecuteScalarAsync<int>("EmployeesTasks_Create", parameters, commandType: CommandType.StoredProcedure);
+    }
+}

--- a/src/EmployeeTasks.Infrastructure/Repositories/UserRepository.cs
+++ b/src/EmployeeTasks.Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,34 @@
+using System.Data;
+using Dapper;
+using EmployeeTasks.Domain.Entities;
+using EmployeeTasks.Application.Common.Interfaces;
+
+namespace EmployeeTasks.Infrastructure.Repositories;
+
+public class UserRepository : IUserRepository
+{
+    private readonly IDbConnection _dbConnection;
+
+    public UserRepository(IDbConnection dbConnection)
+    {
+        _dbConnection = dbConnection;
+    }
+
+    public async Task<string> Users_Create(User user)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("@FullName", user.FullName);
+        parameters.Add("@UserName", user.UserName);
+        parameters.Add("@Password", user.Password);
+        parameters.Add("@PhoneNumber", user.PhoneNumber);
+        parameters.Add("@Address", user.Address);
+        return await _dbConnection.ExecuteScalarAsync<string>("Users_Create", parameters, commandType: CommandType.StoredProcedure);
+    }
+
+    public async Task<User?> Users_GetByUserName(string userName)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("@UserName", userName);
+        return await _dbConnection.QueryFirstOrDefaultAsync<User>("Users_GetByUserName", parameters, commandType: CommandType.StoredProcedure);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold clean architecture solution for EmployeeTasks
- implement minimal API endpoints using Dapper
- add JWT login and register endpoints

## Testing
- `dotnet build EmployeeTasks.sln`

------
https://chatgpt.com/codex/tasks/task_e_6845f9e3ddc48323aa09040d162136df